### PR TITLE
Fix pixels rounding errors in fractional pixels media queries

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,15 @@ module.exports = postcss.plugin('postcss-media-minmax', function () {
 
     function create_query(name, gtlt, eq, value, params) {
       return value.replace(/([-\d\.]+)(.*)/, function (match, number, unit) {
-        number = parseFloat(number) || eq ? eq ? number : Number(Math.round(parseFloat(number) + step * power[gtlt] + 'e6')+'e-6') : power[gtlt] + feature_unit[name];
+
+        if (parseFloat(number) || eq) {
+          // if eq is true, then number remains same
+          if (!eq) {
+            number = Number(Math.round(parseFloat(number) + step * power[gtlt] + 'e6')+'e-6');
+          }
+        } else {
+          number = power[gtlt] + feature_unit[name];
+        }
 
         return '(' + minmax[gtlt] + '-' + name + ': ' + number + unit + ')';
       });

--- a/index.js
+++ b/index.js
@@ -32,11 +32,17 @@ module.exports = postcss.plugin('postcss-media-minmax', function () {
 
     function create_query(name, gtlt, eq, value, params) {
       return value.replace(/([-\d\.]+)(.*)/, function (match, number, unit) {
+        var initialNumber = parseFloat(number);
 
         if (parseFloat(number) || eq) {
           // if eq is true, then number remains same
           if (!eq) {
-            number = Number(Math.round(parseFloat(number) + step * power[gtlt] + 'e6')+'e-6');
+            // change integer pixels value only on integer pixel
+            if (unit === 'px' && initialNumber === parseInt(number, 10)) {
+              number = initialNumber + power[gtlt];
+            } else {
+              number = Number(Math.round(parseFloat(number) + step * power[gtlt] + 'e6')+'e-6');
+            }
           }
         } else {
           number = power[gtlt] + feature_unit[name];

--- a/test/fixtures/min-max.output.css
+++ b/test/fixtures/min-max.output.css
@@ -1,8 +1,8 @@
-@media screen and (min-width: 500.001px) and (max-width: 1199.999px) {
+@media screen and (min-width: 501px) and (max-width: 1199px) {
 
 }
 
-@media screen and (min-width: 500.001px) and (max-width: 1199.999px) {
+@media screen and (min-width: 501px) and (max-width: 1199px) {
 
 }
 
@@ -26,11 +26,11 @@
 }
 
 /* height */
-@media screen and (min-height: 500.001px) and (max-height: 1199.999px) {
+@media screen and (min-height: 501px) and (max-height: 1199px) {
 
 }
 
-@media screen and (min-height: 500.001px) and (max-height: 1199.999px) {
+@media screen and (min-height: 501px) and (max-height: 1199px) {
 
 }
 


### PR DESCRIPTION
Recently I ran into issue in Safari on iOS 8.4 and iOS 9.1 when media queries with `max-width: 767.999px` and with `min-width: 768px` both applied to the page. So this PR fixes current plugin behaviour with fractional _pixels_ value. But it only fixes value if value was integer before transformation.

Input:

```css
@media screen and (width > 500px) and (width < 1200px) {}
@media screen and (500px < width < 1200px) {}
@media screen and (0 < width < 500.58px) {}
```

Output before PR:

```css
@media screen and (min-width: 500.001px) and (max-width: 1199.999px) {
@media screen and (min-width: 500.001px) and (max-width: 1199.999px) {
@media screen and (min-width: 1px) and (max-width: 500.579px) {}
```

Output after PR:

```css
@media screen and (min-width: 501px) and (max-width: 1199px) {}
@media screen and (min-width: 501px) and (max-width: 1199px) {}
@media screen and (min-width: 1px) and (max-width: 500.579px) {}
```

Discussion about this browsers issue had place in issue https://github.com/postcss/postcss-media-minmax/issues/12 but this PR *not* fixed issue, because that issue about order, not values.