### PR TITLE
Update to PostCSS 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+node_js:
+  - 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.0 2017-05-10
+
+Change: Use PostCSS 6 API.
+
 # 2.1.2 2016-04-01
 
 Fix: incorrect output when using both > and >= (or similar).(#12)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-media-minmax",
-  "version": "2.1.2",
+  "version": "3.0.0",
   "description": "Using more intuitive `>=`, `<=`, `>`, `<` instead of media queries min/max prefix.",
   "scripts": {
     "test": "tape test"

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "index.js"
   ],
   "dependencies": {
-    "postcss": "^5.0.4"
+    "postcss": "^6.0.1"
   },
   "devDependencies": {
-    "tape": "^3.0.0"
+    "tape": "^4.6.3"
   },
   "bugs": {
     "url": "https://github.com/postcss/postcss-media-minmax/issues"

--- a/test/fixtures/comment.output.css
+++ b/test/fixtures/comment.output.css
@@ -1,10 +1,10 @@
-@media screen and  (min-width: 500px)  and (max-width: 1200px)/* comment */ {
+@media screen and  (min-width: 500px)  and (max-width: 1200px) /* comment */{
   .bar {
     display: block;
   }
 }
 
-@media screen and (min-width: 500px) and (max-width: 1200px)/* comment */ {
+@media screen and (min-width: 500px) and (max-width: 1200px) /* comment */{
   .bar {
     display: block;
   }


### PR DESCRIPTION
This commit updates your dependencies to use PostCSS 6.

It also:
- Updates travis.yml to test against Node v4, a requirement of PostCSS 6.
- Fixes one test where PostCSS previously reformatted whitespace incorrectly.
- Bumps the major version for your next release and adds an entry to the CHANGELOG.md. :)