### PR TITLE
Change integer pixels by .02px rather than 1px

### DIFF
--- a/test/fixtures/min-max.output.css
+++ b/test/fixtures/min-max.output.css
@@ -1,6 +1,6 @@
-@media screen and (min-width: 501px) and (max-width: 1199px) {}
+@media screen and (min-width: 500.02px) and (max-width: 1199.98px) {}
 
-@media screen and (min-width: 501px) and (max-width: 1199px) {}
+@media screen and (min-width: 500.02px) and (max-width: 1199.98px) {}
 
 @media screen and (min-width: 40.001em) and (max-width: 59.999em) {}
 
@@ -8,14 +8,14 @@
 
 @media screen and (min-width: 6.001in) and (max-width: 8.999in) {}
 
-@media screen and (min-width: 1px) and (max-width: 500.579px) {}
+@media screen and (min-width: 0.02px) and (max-width: 500.579px) {}
 
 @media screen and (width) and (min-width: 0.081px) and (max-width: 0.679px) {}
 
 /* height */
-@media screen and (min-height: 501px) and (max-height: 1199px) {}
+@media screen and (min-height: 500.02px) and (max-height: 1199.98px) {}
 
-@media screen and (min-height: 501px) and (max-height: 1199px) {}
+@media screen and (min-height: 500.02px) and (max-height: 1199.98px) {}
 
 @media screen and (min-height: 40.001em) and (max-height: 59.999em) {}
 
@@ -23,6 +23,6 @@
 
 @media screen and (min-height: 6.001in) and (max-height: 8.999in) {}
 
-@media screen and (min-height: 1px) and (max-height: 500.579px) {}
+@media screen and (min-height: 0.02px) and (max-height: 500.579px) {}
 
 @media screen and (height) and (min-height: 0.081px) and (max-height: 0.679px) {}

--- a/test/fixtures/shorthands.output.css
+++ b/test/fixtures/shorthands.output.css
@@ -1,11 +1,11 @@
-@media (min-width: 768px) and (max-width: 1023px) {}
-@media (min-width: 768px) and (max-width: 1023px) {}
+@media (min-width: 768px) and (max-width: 1023.98px) {}
+@media (min-width: 768px) and (max-width: 1023.98px) {}
 
-@media (min-width: 769px) and (max-width: 1024px) {}
-@media (min-width: 769px) and (max-width: 1024px) {}
+@media (min-width: 768.02px) and (max-width: 1024px) {}
+@media (min-width: 768.02px) and (max-width: 1024px) {}
 
 @media (min-width: 768px) and (max-width: 1024px) {}
 @media (min-width: 768px) and (max-width: 1024px) {}
 
-@media (min-width: 769px) and (max-width: 1023px) {}
-@media (min-width: 769px) and (max-width: 1023px) {}
+@media (min-width: 768.02px) and (max-width: 1023.98px) {}
+@media (min-width: 768.02px) and (max-width: 1023.98px) {}


### PR DESCRIPTION
According to the Bootstrap developers, using .02px rather than .01px should be sufficient to work around the Safari rounding bug.

Fixes #19.